### PR TITLE
Add `frameOnly` Props

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,10 +7,10 @@ module.exports = {
 	rules: {
 		quotes: [1, "double"], // 쌍따옴표 사용
 		"no-mixed-spaces-and-tabs": [1, "smart-tabs"], // 탭, 띄어쓰기 혼용을 코드 alignment로 사용되었을 때만 허용
-		"react-native/no-inline-styles": 0, // inline-style 허용
-		"@typescript-eslint/no-unused-vars": 0, // 사용하지 않은 변수 무시
+		// "react-native/no-inline-styles": 0, // inline-style 허용
+		"@typescript-eslint/no-unused-vars": 1, // 사용하지 않은 변수 무시
 		"prettier/prettier": [
-			"error",
+			1,
 			{
 				endOfLine: "auto",
 			},

--- a/Develop/App.tsx
+++ b/Develop/App.tsx
@@ -14,9 +14,9 @@ import {
   TextStyle,
   TouchableHighlight,
   TouchableOpacity,
-  useColorScheme,
   View,
   ViewStyle,
+  useColorScheme,
 } from 'react-native';
 import {
   AndroidMockup,
@@ -188,6 +188,7 @@ function App(): React.JSX.Element {
             // isLandscape={false}
             containerStlye={mockupContainerStyle}
             // frameColor="green"
+            // frameOnly
             // statusbarColor="red"
             hideStatusBar
             navBar="bhr"
@@ -202,6 +203,7 @@ function App(): React.JSX.Element {
             isLandscape={true}
             containerStlye={mockupContainerStyle}
             // frameColor="green"
+            // frameOnly
             // statusbarColor="red"
             hideStatusBar
             navBar="bhr"
@@ -221,6 +223,7 @@ function App(): React.JSX.Element {
             // noRoundedScreen
             containerStlye={mockupContainerStyle}
             // frameColor="green"
+            // frameOnly
             // statusbarColor="red"
             // hideStatusBar
             // navBar="rhb"
@@ -236,6 +239,7 @@ function App(): React.JSX.Element {
             // noRoundedScreen
             containerStlye={mockupContainerStyle}
             // frameColor="green"
+            // frameOnly
             // statusbarColor="red"
             // hideStatusBar
             // navBar="rhb"
@@ -255,6 +259,7 @@ function App(): React.JSX.Element {
             // isLandscape={false}
             containerStlye={mockupContainerStyle}
             // frameColor="green"
+            // frameOnly
             // statusbarColor="red"
             // hideStatusBar
             // transparentNavBar
@@ -268,6 +273,7 @@ function App(): React.JSX.Element {
             isLandscape={true}
             containerStlye={mockupContainerStyle}
             // frameColor="green"
+            // frameOnly
             // statusbarColor="red"
             // hideStatusBar
             // transparentNavBar
@@ -285,6 +291,7 @@ function App(): React.JSX.Element {
             isLandscape={false}
             containerStlye={mockupContainerStyle}
             // frameColor="green"
+            // frameOnly
             // statusbarColor="red"
             // hideStatusBar
             // transparentNavBar
@@ -298,6 +305,7 @@ function App(): React.JSX.Element {
             isLandscape={true}
             containerStlye={mockupContainerStyle}
             // frameColor="green"
+            // frameOnly
             // statusbarColor="red"
             // hideStatusBar
             // transparentNavBar
@@ -315,6 +323,7 @@ function App(): React.JSX.Element {
             isLandscape={false}
             containerStlye={mockupContainerStyle}
             // frameColor="green"
+            // frameOnly
             // statusbarColor="red"
             // hideStatusBar
             // transparentNavBar
@@ -328,6 +337,7 @@ function App(): React.JSX.Element {
             isLandscape={true}
             containerStlye={mockupContainerStyle}
             // frameColor="green"
+            // frameOnly
             // statusbarColor="red"
             // hideStatusBar
             // transparentNavBar
@@ -375,6 +385,7 @@ function App(): React.JSX.Element {
             isLandscape={false}
             containerStlye={mockupContainerStyle}
             // frameColor="green"
+            // frameOnly
             // statusbarColor="red"
             // hideStatusBar
             // transparentNavBar
@@ -388,6 +399,7 @@ function App(): React.JSX.Element {
             isLandscape={true}
             containerStlye={mockupContainerStyle}
             // frameColor="green"
+            // frameOnly
             // statusbarColor="red"
             // hideStatusBar
             // transparentNavBar

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ You can use this library when you need a device demo for your app.
 **Every mockup is rendered as a pure react-native `View` component.**
 
 `react-native-device-mockup` provides the following mockups:
-> **you can find [🌐 full-demo-here](https://jung-youngmin.github.io/react-device-mockup-demo/)**
+> You can check out the
+> [🌐 full-demo-here](https://jung-youngmin.github.io/react-device-mockup-demo/)  
+> Package for **React** is [🌐 here](https://github.com/jung-youngmin/react-device-mockup)
 
 1. Android
    1. Phone: 19.5:9 aspect ratio, `AndroidMockup`
@@ -106,6 +108,7 @@ You can check [demo](#demo-android)
 | isLandscape        | X        | `boolean` | `false` | portrait or landscape<br>`false` means portrait |
 | containerStlye     | X        | `ViewStyle` | | Styles for mockup container |
 | frameColor         | X        | `ColorValue` | `"#666666"` | Color of Frame |
+| frameOnly          | X        | `boolean` | `false` | Only the frame is shown.<br>Power button and volume buttons are hidden |
 | statusbarColor     | X        | `ColorValue` | `"#CCCCCC"` | Color of status bar |
 | hideStatusBar      | X        | `boolean`    | `false` | Hide the status bar<br>[details](#hidestatusbar) |
 | navBar             | X        | `"swipe"`<br>`"bhr"`<br>`"rhb"` | `"swipe"` | Type of navigation bar<br>[details](#navbar) |
@@ -129,6 +132,7 @@ You can check [demo](#demo-ios)
 | isLandscape | X | `boolean` | `false` | portrait or landscape<br>`false` means portrait |
 | containerStlye | X | `ViewStyle` | | Styles for mockup container |
 | frameColor | X | `ColorValue` | `"#666666"` | Color of Frame |
+| frameOnly          | X        | `boolean` | `false` | Only the frame is shown.<br>Power button and volume buttons are hidden |
 | statusbarColor | X | `ColorValue` | `"#CCCCCC"` | Color of status bar |
 | hideStatusBar | X | `boolean` | `false` | Hide the status bar<br>[details](#hidestatusbar) |
 | transparentNavBar | X | `boolean` | `false` | Make the navigation bar transparent.<br>[details](#transparentnavbar) |

--- a/src/android-mockup/AndroidMockup.tsx
+++ b/src/android-mockup/AndroidMockup.tsx
@@ -1,7 +1,7 @@
 import React, { PropsWithChildren, useMemo } from "react";
 import { ColorValue, StyleProp, View, ViewStyle } from "react-native";
-import AndroidPortrait from "./variants/phone/AndroidPortrait";
 import AndroidLandscape from "./variants/phone/AndroidLandscape";
+import AndroidPortrait from "./variants/phone/AndroidPortrait";
 
 interface IAndroidMockupProps {
 	readonly screenWidth: number;
@@ -12,6 +12,8 @@ interface IAndroidMockupProps {
 	readonly containerStlye?: StyleProp<ViewStyle>;
 	/** default: "#666666" */
 	readonly frameColor?: ColorValue;
+	/** default: false */
+	readonly frameOnly?: boolean;
 	/** default: "#CCCCCC" */
 	readonly statusbarColor?: ColorValue;
 	/** default: false */
@@ -41,6 +43,10 @@ export default function AndroidMockup(props: AndroidMockupProps) {
 	const frameColor = useMemo(() => {
 		return props.frameColor === undefined ? "#666666" : props.frameColor;
 	}, [props.frameColor]);
+
+	const frameOnly = useMemo(() => {
+		return props.frameOnly === undefined ? false : props.frameOnly;
+	}, [props.frameOnly]);
 
 	const statusbarColor = useMemo(() => {
 		return props.statusbarColor === undefined ? "#CCCCCC" : props.statusbarColor;
@@ -77,6 +83,7 @@ export default function AndroidMockup(props: AndroidMockupProps) {
 					screenWidth={props.screenWidth}
 					screenRounded={!noRoundedScreen}
 					frameColor={frameColor}
+					frameOnly={frameOnly}
 					statusbarColor={statusbarColor}
 					navigationBar={navigationBar}
 					navigationBarcolor={navigationBarcolor}
@@ -91,6 +98,7 @@ export default function AndroidMockup(props: AndroidMockupProps) {
 					screenWidth={props.screenWidth}
 					screenRounded={!noRoundedScreen}
 					frameColor={frameColor}
+					frameOnly={frameOnly}
 					statusbarColor={statusbarColor}
 					navigationBar={navigationBar}
 					navigationBarcolor={navigationBarcolor}

--- a/src/android-mockup/AndroidTabMockup.tsx
+++ b/src/android-mockup/AndroidTabMockup.tsx
@@ -1,7 +1,7 @@
 import React, { PropsWithChildren, useMemo } from "react";
 import { ColorValue, StyleProp, View, ViewStyle } from "react-native";
-import AndroidTabPortrait from "./variants/tab/AndroidTabPortrait";
 import AndroidTabLandscape from "./variants/tab/AndroidTabLandscape";
+import AndroidTabPortrait from "./variants/tab/AndroidTabPortrait";
 
 interface IAndroidTabMockupProps {
 	readonly screenWidth: number;
@@ -13,6 +13,8 @@ interface IAndroidTabMockupProps {
 	readonly containerStlye?: StyleProp<ViewStyle>;
 	/** default: "#666666" */
 	readonly frameColor?: ColorValue;
+	/** default: false */
+	readonly frameOnly?: boolean;
 	/** default: "#CCCCCC" */
 	readonly statusbarColor?: ColorValue;
 	/** default: false */
@@ -40,6 +42,10 @@ export default function AndroidTabMockup(props: AndroidTabMockupProps) {
 	const frameColor = useMemo(() => {
 		return props.frameColor === undefined ? "#666666" : props.frameColor;
 	}, [props.frameColor]);
+
+	const frameOnly = useMemo(() => {
+		return props.frameOnly === undefined ? false : props.frameOnly;
+	}, [props.frameOnly]);
 
 	const statusbarColor = useMemo(() => {
 		return props.statusbarColor === undefined ? "#CCCCCC" : props.statusbarColor;
@@ -72,6 +78,7 @@ export default function AndroidTabMockup(props: AndroidTabMockupProps) {
 					screenWidth={props.screenWidth}
 					screenRounded={!noRoundedScreen}
 					frameColor={frameColor}
+					frameOnly={frameOnly}
 					statusbarColor={statusbarColor}
 					navigationBar={navigationBar}
 					navigationBarcolor={navigationBarcolor}
@@ -85,6 +92,7 @@ export default function AndroidTabMockup(props: AndroidTabMockupProps) {
 					screenWidth={props.screenWidth}
 					screenRounded={!noRoundedScreen}
 					frameColor={frameColor}
+					frameOnly={frameOnly}
 					statusbarColor={statusbarColor}
 					navigationBar={navigationBar}
 					navigationBarcolor={navigationBarcolor}

--- a/src/android-mockup/variants/phone/AndroidLandscape.tsx
+++ b/src/android-mockup/variants/phone/AndroidLandscape.tsx
@@ -1,13 +1,15 @@
 import React, { PropsWithChildren, useMemo } from "react";
-import { ColorValue, StyleSheet, View } from "react-native";
+import { ColorValue, StyleSheet, View, ViewStyle } from "react-native";
 import { IAndroidMockupVariantProps } from "../variants-interface";
 
 export default function AndroidLandscape(
 	props: PropsWithChildren<IAndroidMockupVariantProps & { readonly transparentCamArea: boolean }>,
 ) {
 	const {
+		screenWidth,
 		screenRounded,
 		frameColor,
+		frameOnly,
 		statusbarColor,
 		navigationBar,
 		navigationBarcolor,
@@ -16,15 +18,21 @@ export default function AndroidLandscape(
 		transparentNavigationBar,
 		transparentCamArea,
 	} = props;
+
 	const styles = useMemo(() => {
 		return getStyles(
-			props.screenWidth,
+			screenWidth,
 			screenRounded,
 			frameColor,
 			statusbarColor,
 			navigationBarcolor,
+			frameOnly,
 		);
-	}, [props.screenWidth, screenRounded, frameColor, statusbarColor, navigationBarcolor]);
+	}, [screenWidth, screenRounded, frameColor, statusbarColor, navigationBarcolor, frameOnly]);
+
+	const flex1 = useMemo<ViewStyle>(() => {
+		return { flex: 1 };
+	}, []);
 
 	return (
 		<View style={styles.container}>
@@ -40,9 +48,9 @@ export default function AndroidLandscape(
 						</View>
 					)}
 					{/* screen content */}
-					<View style={{ flex: 1 }}>
+					<View style={flex1}>
 						{hideStatusBar === false && <View style={styles.statusbar} />}
-						<View style={{ flex: 1 }}>{props.children}</View>
+						<View style={flex1}>{props.children}</View>
 						{/* navigation bar - swipe */}
 						{hideNavigationBar === false &&
 							navigationBar === "swipe" &&
@@ -106,8 +114,12 @@ export default function AndroidLandscape(
 						))}
 				</View>
 			</View>
-			<View style={styles.volumeLandscape} />
-			<View style={styles.powerLandscape} />
+			{!frameOnly && (
+				<>
+					<View style={styles.volumeLandscape} />
+					<View style={styles.powerLandscape} />
+				</>
+			)}
 		</View>
 	);
 }
@@ -118,6 +130,7 @@ const getStyles = (
 	frameColor: ColorValue,
 	statusbarColor: ColorValue,
 	navigationBarcolor: ColorValue,
+	frameOnly: boolean,
 ) => {
 	const getSizeWithRatio = (size: number) => {
 		const sizeRatio = Math.floor((screenWidth * size) / 2340);
@@ -142,7 +155,7 @@ const getStyles = (
 			height: heightAndFrame,
 			borderRadius: screenRounded ? getSizeWithRatio(140) : getSizeWithRatio(30),
 			backgroundColor: frameColor,
-			marginTop: frameButtonHeight - HALF_FRAME_WIDTH + 1,
+			marginTop: frameOnly ? 0 : frameButtonHeight - HALF_FRAME_WIDTH + 1,
 		},
 		frame: {
 			width: widthAndFrame,

--- a/src/android-mockup/variants/phone/AndroidPortrait.tsx
+++ b/src/android-mockup/variants/phone/AndroidPortrait.tsx
@@ -1,5 +1,5 @@
 import React, { PropsWithChildren, useMemo } from "react";
-import { ColorValue, StyleSheet, View } from "react-native";
+import { ColorValue, StyleSheet, View, ViewStyle } from "react-native";
 import { IAndroidMockupVariantProps } from "../variants-interface";
 
 export default function AndroidPortrait(props: PropsWithChildren<IAndroidMockupVariantProps>) {
@@ -7,6 +7,7 @@ export default function AndroidPortrait(props: PropsWithChildren<IAndroidMockupV
 		screenWidth,
 		screenRounded,
 		frameColor,
+		frameOnly,
 		statusbarColor,
 		navigationBar,
 		navigationBarcolor,
@@ -21,8 +22,13 @@ export default function AndroidPortrait(props: PropsWithChildren<IAndroidMockupV
 			frameColor,
 			statusbarColor,
 			navigationBarcolor,
+			frameOnly,
 		);
-	}, [screenWidth, screenRounded, frameColor, statusbarColor, navigationBarcolor]);
+	}, [screenWidth, screenRounded, frameColor, statusbarColor, navigationBarcolor, frameOnly]);
+
+	const flex1 = useMemo<ViewStyle>(() => {
+		return { flex: 1 };
+	}, []);
 
 	return (
 		<View style={styles.container}>
@@ -38,7 +44,7 @@ export default function AndroidPortrait(props: PropsWithChildren<IAndroidMockupV
 						</View>
 					)}
 					{/* screen content */}
-					<View style={{ flex: 1 }}>{props.children}</View>
+					<View style={flex1}>{props.children}</View>
 					{/* camera - fullScreen - portrait */}
 					{hideStatusBar && <View style={styles.cameraFullScreenPortrait} />}
 
@@ -96,8 +102,12 @@ export default function AndroidPortrait(props: PropsWithChildren<IAndroidMockupV
 						))}
 				</View>
 			</View>
-			<View style={styles.volumePortrait} />
-			<View style={styles.powerPortrait} />
+			{!frameOnly && (
+				<>
+					<View style={styles.volumePortrait} />
+					<View style={styles.powerPortrait} />
+				</>
+			)}
 		</View>
 	);
 }
@@ -108,6 +118,7 @@ const getStyles = (
 	frameColor: ColorValue,
 	statusbarColor: ColorValue,
 	navigationBarcolor: ColorValue,
+	frameOnly: boolean,
 ) => {
 	const getSizeWithRatio = (size: number) => {
 		const sizeRatio = Math.floor((screenWidth * size) / 1080);
@@ -132,7 +143,7 @@ const getStyles = (
 			height: heightAndFrame,
 			borderRadius: screenRounded ? getSizeWithRatio(140) : getSizeWithRatio(30),
 			backgroundColor: frameColor,
-			marginRight: frameButtonWidth - HALF_FRAME_WIDTH + 1,
+			marginRight: frameOnly ? 0 : frameButtonWidth - HALF_FRAME_WIDTH + 1,
 		},
 		frame: {
 			width: widthAndFrame,

--- a/src/android-mockup/variants/tab/AndroidTabLandscape.tsx
+++ b/src/android-mockup/variants/tab/AndroidTabLandscape.tsx
@@ -1,11 +1,13 @@
 import React, { PropsWithChildren, useMemo } from "react";
-import { ColorValue, StyleSheet, View } from "react-native";
+import { ColorValue, StyleSheet, View, ViewStyle } from "react-native";
 import { IAndroidMockupVariantProps } from "../variants-interface";
 
 export default function AndroidTabLandscape(props: PropsWithChildren<IAndroidMockupVariantProps>) {
 	const {
+		screenWidth,
 		screenRounded,
 		frameColor,
+		frameOnly,
 		statusbarColor,
 		navigationBar,
 		navigationBarcolor,
@@ -15,13 +17,18 @@ export default function AndroidTabLandscape(props: PropsWithChildren<IAndroidMoc
 	} = props;
 	const styles = useMemo(() => {
 		return getStyles(
-			props.screenWidth,
+			screenWidth,
 			screenRounded,
 			frameColor,
 			statusbarColor,
 			navigationBarcolor,
+			frameOnly,
 		);
-	}, [props.screenWidth, screenRounded, frameColor, statusbarColor, navigationBarcolor]);
+	}, [screenWidth, screenRounded, frameColor, statusbarColor, navigationBarcolor, frameOnly]);
+
+	const flex1 = useMemo<ViewStyle>(() => {
+		return { flex: 1 };
+	}, []);
 
 	return (
 		<View style={styles.container}>
@@ -32,8 +39,8 @@ export default function AndroidTabLandscape(props: PropsWithChildren<IAndroidMoc
 					{/* status bar */}
 					{hideStatusBar === false && <View style={styles.statusbarPortrait} />}
 					{/* screen content */}
-					<View style={{ flex: 1 }}>
-						<View style={{ flex: 1 }}>{props.children}</View>
+					<View style={flex1}>
+						<View style={flex1}>{props.children}</View>
 					</View>
 					{/* navigation bar - swipe */}
 					{hideNavigationBar === false &&
@@ -89,8 +96,12 @@ export default function AndroidTabLandscape(props: PropsWithChildren<IAndroidMoc
 			<View style={styles.cameraLandscapeContainer}>
 				<View style={styles.camera} />
 			</View>
-			<View style={styles.volumeLandscape} />
-			<View style={styles.powerLandscape} />
+			{!frameOnly && (
+				<>
+					<View style={styles.volumeLandscape} />
+					<View style={styles.powerLandscape} />
+				</>
+			)}
 		</View>
 	);
 }
@@ -101,6 +112,7 @@ const getStyles = (
 	frameColor: ColorValue,
 	statusbarColor: ColorValue,
 	navigationBarcolor: ColorValue,
+	frameOnly: boolean,
 ) => {
 	const getSizeWithRatio = (size: number) => {
 		const sizeRatio = Math.floor((screenWidth * size) / 2560);
@@ -125,7 +137,7 @@ const getStyles = (
 			height: heightAndFrame,
 			borderRadius: screenRounded ? getSizeWithRatio(140) : getSizeWithRatio(30),
 			backgroundColor: frameColor,
-			marginTop: frameButtonHeight - HALF_FRAME_WIDTH,
+			marginTop: frameOnly ? 0 : frameButtonHeight - HALF_FRAME_WIDTH,
 		},
 		frame: {
 			width: widthAndFrame,

--- a/src/android-mockup/variants/tab/AndroidTabPortrait.tsx
+++ b/src/android-mockup/variants/tab/AndroidTabPortrait.tsx
@@ -1,5 +1,5 @@
 import React, { PropsWithChildren, useMemo } from "react";
-import { ColorValue, StyleSheet, View } from "react-native";
+import { ColorValue, StyleSheet, View, ViewStyle } from "react-native";
 import { IAndroidMockupVariantProps } from "../variants-interface";
 
 export default function AndroidTabPortrait(props: PropsWithChildren<IAndroidMockupVariantProps>) {
@@ -7,6 +7,7 @@ export default function AndroidTabPortrait(props: PropsWithChildren<IAndroidMock
 		screenWidth,
 		screenRounded,
 		frameColor,
+		frameOnly,
 		statusbarColor,
 		navigationBar,
 		navigationBarcolor,
@@ -21,8 +22,13 @@ export default function AndroidTabPortrait(props: PropsWithChildren<IAndroidMock
 			frameColor,
 			statusbarColor,
 			navigationBarcolor,
+			frameOnly,
 		);
-	}, [screenWidth, screenRounded, frameColor, statusbarColor, navigationBarcolor]);
+	}, [screenWidth, screenRounded, frameColor, statusbarColor, navigationBarcolor, frameOnly]);
+
+	const flex1 = useMemo<ViewStyle>(() => {
+		return { flex: 1 };
+	}, []);
 
 	return (
 		<View style={styles.container}>
@@ -31,10 +37,10 @@ export default function AndroidTabPortrait(props: PropsWithChildren<IAndroidMock
 				{/* screen */}
 				<View style={styles.screen}>
 					{/* status bar */}
-					{hideStatusBar === false && <View style={styles.statusbarPortrait}></View>}
+					{hideStatusBar === false && <View style={styles.statusbarPortrait} />}
 					{/* screen content */}
-					<View style={{ flex: 1 }}>
-						<View style={{ flex: 1 }}>{props.children}</View>
+					<View style={flex1}>
+						<View style={flex1}>{props.children}</View>
 					</View>
 					{/* navigation bar - swipe */}
 					{hideNavigationBar === false &&
@@ -66,7 +72,6 @@ export default function AndroidTabPortrait(props: PropsWithChildren<IAndroidMock
 								<View style={styles.square} />
 							</View>
 						))}
-
 					{/* navigation bar - portrait - rhb */}
 					{hideNavigationBar === false &&
 						navigationBar === "rhb" &&
@@ -91,8 +96,12 @@ export default function AndroidTabPortrait(props: PropsWithChildren<IAndroidMock
 			<View style={styles.cameraPortraitContainer}>
 				<View style={styles.camera} />
 			</View>
-			<View style={styles.volumePortrait} />
-			<View style={styles.powerPortrait} />
+			{!frameOnly && (
+				<>
+					<View style={styles.volumePortrait} />
+					<View style={styles.powerPortrait} />
+				</>
+			)}
 		</View>
 	);
 }
@@ -103,6 +112,7 @@ const getStyles = (
 	frameColor: ColorValue,
 	statusbarColor: ColorValue,
 	navigationBarcolor: ColorValue,
+	frameOnly: boolean,
 ) => {
 	const getSizeWithRatio = (size: number) => {
 		const sizeRatio = Math.floor((screenWidth * size) / 1600);
@@ -127,7 +137,7 @@ const getStyles = (
 			height: heightAndFrame,
 			borderRadius: screenRounded ? getSizeWithRatio(140) : getSizeWithRatio(30),
 			backgroundColor: frameColor,
-			marginRight: frameButtonWidth - HALF_FRAME_WIDTH + 1,
+			marginRight: frameOnly ? 0 : frameButtonWidth - HALF_FRAME_WIDTH + 1,
 		},
 		frame: {
 			width: widthAndFrame,

--- a/src/android-mockup/variants/variants-interface.ts
+++ b/src/android-mockup/variants/variants-interface.ts
@@ -6,6 +6,8 @@ export interface IAndroidMockupVariantProps {
 	readonly screenRounded: boolean;
 	/** default: "#666666" */
 	readonly frameColor: ColorValue;
+	/** default: false */
+	readonly frameOnly: boolean;
 	/** default: "#CCCCCC" */
 	readonly statusbarColor: ColorValue;
 	/** default: "#CCCCCC" */

--- a/src/ios-mockup/IPadMockup.tsx
+++ b/src/ios-mockup/IPadMockup.tsx
@@ -1,9 +1,9 @@
 import React, { PropsWithChildren, useMemo } from "react";
 import { ColorValue, StyleProp, View, ViewStyle } from "react-native";
-import IPadLegacyPortrait from "./variants/tab/IPadLegacyPortrait";
 import IPadLegacyLandscape from "./variants/tab/IPadLegacyLandscape";
-import IPadModernPortrait from "./variants/tab/IPadModernPortrait";
+import IPadLegacyPortrait from "./variants/tab/IPadLegacyPortrait";
 import IPadModernLandscape from "./variants/tab/IPadModernLandscape";
+import IPadModernPortrait from "./variants/tab/IPadModernPortrait";
 
 interface IiPadMockupProps {
 	readonly screenWidth: number;
@@ -14,6 +14,8 @@ interface IiPadMockupProps {
 	readonly containerStlye?: StyleProp<ViewStyle>;
 	/** default: "#666666" */
 	readonly frameColor?: ColorValue;
+	/** default: false */
+	readonly frameOnly?: boolean;
 	/** default: "#CCCCCC" */
 	readonly statusbarColor?: ColorValue;
 	/** default: false */
@@ -37,6 +39,10 @@ export default function IPadMockup(props: IPadMockupProps) {
 	const frameColor = useMemo(() => {
 		return props.frameColor === undefined ? "#666666" : props.frameColor;
 	}, [props.frameColor]);
+
+	const frameOnly = useMemo(() => {
+		return props.frameOnly === undefined ? false : props.frameOnly;
+	}, [props.frameOnly]);
 
 	const statusbarColor = useMemo(() => {
 		return props.statusbarColor === undefined ? "#CCCCCC" : props.statusbarColor;
@@ -80,6 +86,7 @@ export default function IPadMockup(props: IPadMockupProps) {
 			<Mockup
 				screenWidth={props.screenWidth}
 				frameColor={frameColor}
+				frameOnly={frameOnly}
 				statusbarColor={statusbarColor}
 				hideStatusBar={hideStatusBar}
 				transparentNavigationBar={transparentNavigationBar}

--- a/src/ios-mockup/IPhoneMockup.tsx
+++ b/src/ios-mockup/IPhoneMockup.tsx
@@ -1,11 +1,11 @@
 import React, { PropsWithChildren, useMemo } from "react";
 import { ColorValue, StyleProp, View, ViewStyle } from "react-native";
-import IPhoneNotchPortrait from "./variants/phone/IPhoneNotchPortrait";
-import IPhoneNotchLandscape from "./variants/phone/IPhoneNotchLandscape";
-import IPhoneIslandPortrait from "./variants/phone/IPhoneIslandPortrait";
 import IPhoneIslandLandscape from "./variants/phone/IPhoneIslandLandscape";
-import IPhoneLegacyPortrait from "./variants/phone/IPhoneLegacyPortrait";
+import IPhoneIslandPortrait from "./variants/phone/IPhoneIslandPortrait";
 import IPhoneLegacyLandscape from "./variants/phone/IPhoneLegacyLandscape";
+import IPhoneLegacyPortrait from "./variants/phone/IPhoneLegacyPortrait";
+import IPhoneNotchLandscape from "./variants/phone/IPhoneNotchLandscape";
+import IPhoneNotchPortrait from "./variants/phone/IPhoneNotchPortrait";
 
 interface IiPhoneMockupProps {
 	readonly screenWidth: number;
@@ -16,6 +16,8 @@ interface IiPhoneMockupProps {
 	readonly containerStlye?: StyleProp<ViewStyle>;
 	/** default: "#666666" */
 	readonly frameColor?: ColorValue;
+	/** default: false */
+	readonly frameOnly?: boolean;
 	/** default: "#CCCCCC" */
 	readonly statusbarColor?: ColorValue;
 	/** default: false */
@@ -39,6 +41,10 @@ export default function IPhoneMockup(props: IPhoneMockupProps) {
 	const frameColor = useMemo(() => {
 		return props.frameColor === undefined ? "#666666" : props.frameColor;
 	}, [props.frameColor]);
+
+	const frameOnly = useMemo(() => {
+		return props.frameOnly === undefined ? false : props.frameOnly;
+	}, [props.frameOnly]);
 
 	const statusbarColor = useMemo(() => {
 		return props.statusbarColor === undefined ? "#CCCCCC" : props.statusbarColor;
@@ -89,6 +95,7 @@ export default function IPhoneMockup(props: IPhoneMockupProps) {
 			<Mockup
 				screenWidth={props.screenWidth}
 				frameColor={frameColor}
+				frameOnly={frameOnly}
 				statusbarColor={statusbarColor}
 				hideStatusBar={hideStatusBar}
 				transparentNavigationBar={transparentNavigationBar}

--- a/src/ios-mockup/variants/phone/IPhoneIslandLandscape.tsx
+++ b/src/ios-mockup/variants/phone/IPhoneIslandLandscape.tsx
@@ -1,18 +1,24 @@
 import React, { PropsWithChildren, useMemo } from "react";
-import { ColorValue, StyleSheet, View } from "react-native";
+import { ColorValue, StyleSheet, View, ViewStyle } from "react-native";
 import { IIosMockupVariantProps } from "../variants-interface";
 
 export default function IPhoneIslandLandscape(props: PropsWithChildren<IIosMockupVariantProps>) {
 	const {
+		screenWidth,
 		frameColor,
+		frameOnly,
 		statusbarColor,
 		hideStatusBar,
 		hideNavigationBar,
 		transparentNavigationBar,
 	} = props;
 	const styles = useMemo(() => {
-		return getStyles(props.screenWidth, frameColor, statusbarColor);
-	}, [props.screenWidth, frameColor, statusbarColor]);
+		return getStyles(screenWidth, frameColor, statusbarColor, frameOnly);
+	}, [screenWidth, frameColor, statusbarColor, frameOnly]);
+
+	const flex1 = useMemo<ViewStyle>(() => {
+		return { flex: 1 };
+	}, []);
 
 	return (
 		<View style={styles.container}>
@@ -22,12 +28,12 @@ export default function IPhoneIslandLandscape(props: PropsWithChildren<IIosMocku
 				<View style={styles.screen}>
 					{hideStatusBar === false && (
 						<View style={styles.notchContainer}>
-							<View style={styles.island}></View>
+							<View style={styles.island} />
 						</View>
 					)}
 					{/* screen content */}
-					<View style={{ flex: 1 }}>
-						<View style={{ flex: 1 }}>{props.children}</View>
+					<View style={flex1}>
+						<View style={flex1}>{props.children}</View>
 						{hideNavigationBar === false && transparentNavigationBar === false && (
 							<View style={styles.swipeContainer}>
 								<View style={styles.swipeBar} />
@@ -38,7 +44,7 @@ export default function IPhoneIslandLandscape(props: PropsWithChildren<IIosMocku
 				</View>
 				{hideStatusBar && (
 					<View pointerEvents="none" style={styles.notchContainerFullScreen}>
-						<View style={styles.island}></View>
+						<View style={styles.island} />
 					</View>
 				)}
 				{hideNavigationBar === false && transparentNavigationBar && (
@@ -47,15 +53,24 @@ export default function IPhoneIslandLandscape(props: PropsWithChildren<IIosMocku
 					</View>
 				)}
 			</View>
-			<View style={styles.silenceSwitch} />
-			<View style={styles.volumeUp} />
-			<View style={styles.volumeDown} />
-			<View style={styles.powerPortrait} />
+			{!frameOnly && (
+				<>
+					<View style={styles.silenceSwitch} />
+					<View style={styles.volumeUp} />
+					<View style={styles.volumeDown} />
+					<View style={styles.powerPortrait} />
+				</>
+			)}
 		</View>
 	);
 }
 
-const getStyles = (screenWidth: number, frameColor: ColorValue, statusbarColor: ColorValue) => {
+const getStyles = (
+	screenWidth: number,
+	frameColor: ColorValue,
+	statusbarColor: ColorValue,
+	frameOnly: boolean,
+) => {
 	const getSizeWithRatio = (size: number) => {
 		const sizeRatio = Math.floor((screenWidth * size) / 844);
 		return Math.max(sizeRatio, 1);
@@ -80,7 +95,7 @@ const getStyles = (screenWidth: number, frameColor: ColorValue, statusbarColor: 
 			borderRadius: bezelRadius,
 			backgroundColor: frameColor,
 			flexDirection: "row",
-			marginVertical: frameButtonHeight - HALF_FRAME_WIDTH,
+			marginVertical: frameOnly ? 0 : frameButtonHeight - HALF_FRAME_WIDTH,
 		},
 		frame: {
 			width: widthAndFrame,

--- a/src/ios-mockup/variants/phone/IPhoneIslandPortrait.tsx
+++ b/src/ios-mockup/variants/phone/IPhoneIslandPortrait.tsx
@@ -1,18 +1,24 @@
 import React, { PropsWithChildren, useMemo } from "react";
-import { ColorValue, StyleSheet, View } from "react-native";
+import { ColorValue, StyleSheet, View, ViewStyle } from "react-native";
 import { IIosMockupVariantProps } from "../variants-interface";
 
 export default function IPhoneIslandPortrait(props: PropsWithChildren<IIosMockupVariantProps>) {
 	const {
+		screenWidth,
 		frameColor,
+		frameOnly,
 		statusbarColor,
 		hideStatusBar,
 		hideNavigationBar,
 		transparentNavigationBar,
 	} = props;
 	const styles = useMemo(() => {
-		return getStyles(props.screenWidth, frameColor, statusbarColor);
-	}, [props.screenWidth, frameColor, statusbarColor]);
+		return getStyles(screenWidth, frameColor, statusbarColor, frameOnly);
+	}, [screenWidth, frameColor, statusbarColor, frameOnly]);
+
+	const flex1 = useMemo<ViewStyle>(() => {
+		return { flex: 1 };
+	}, []);
 
 	return (
 		<View style={styles.container}>
@@ -22,11 +28,11 @@ export default function IPhoneIslandPortrait(props: PropsWithChildren<IIosMockup
 				<View style={styles.screen}>
 					{hideStatusBar === false && (
 						<View style={styles.notchContainer}>
-							<View style={styles.island}></View>
+							<View style={styles.island} />
 						</View>
 					)}
 					{/* screen content */}
-					<View style={{ flex: 1 }}>{props.children}</View>
+					<View style={flex1}>{props.children}</View>
 					{hideNavigationBar === false && transparentNavigationBar === false && (
 						<View style={styles.swipeContainer}>
 							<View style={styles.swipeBar} />
@@ -35,7 +41,7 @@ export default function IPhoneIslandPortrait(props: PropsWithChildren<IIosMockup
 				</View>
 				{hideStatusBar && (
 					<View pointerEvents="none" style={styles.notchContainerFullScreen}>
-						<View style={styles.island}></View>
+						<View style={styles.island} />
 					</View>
 				)}
 				{hideNavigationBar === false && transparentNavigationBar && (
@@ -44,15 +50,24 @@ export default function IPhoneIslandPortrait(props: PropsWithChildren<IIosMockup
 					</View>
 				)}
 			</View>
-			<View style={styles.silenceSwitch} />
-			<View style={styles.volumeUp} />
-			<View style={styles.volumeDown} />
-			<View style={styles.powerPortrait} />
+			{!frameOnly && (
+				<>
+					<View style={styles.silenceSwitch} />
+					<View style={styles.volumeUp} />
+					<View style={styles.volumeDown} />
+					<View style={styles.powerPortrait} />
+				</>
+			)}
 		</View>
 	);
 }
 
-const getStyles = (screenWidth: number, frameColor: ColorValue, statusbarColor: ColorValue) => {
+const getStyles = (
+	screenWidth: number,
+	frameColor: ColorValue,
+	statusbarColor: ColorValue,
+	frameOnly: boolean,
+) => {
 	const getSizeWithRatio = (size: number) => {
 		const sizeRatio = Math.floor((screenWidth * size) / 390);
 		return Math.max(sizeRatio, 1);
@@ -76,7 +91,7 @@ const getStyles = (screenWidth: number, frameColor: ColorValue, statusbarColor: 
 			height: heightAndFrame,
 			borderRadius: bezelRadius,
 			backgroundColor: frameColor,
-			marginHorizontal: frameButtonWidth - HALF_FRAME_WIDTH,
+			marginHorizontal: frameOnly ? 0 : frameButtonWidth - HALF_FRAME_WIDTH,
 		},
 		frame: {
 			width: widthAndFrame,

--- a/src/ios-mockup/variants/phone/IPhoneLegacyLandscape.tsx
+++ b/src/ios-mockup/variants/phone/IPhoneLegacyLandscape.tsx
@@ -1,19 +1,23 @@
 import React, { PropsWithChildren, useMemo } from "react";
-import { ColorValue, StyleSheet, View } from "react-native";
+import { ColorValue, StyleSheet, View, ViewStyle } from "react-native";
 import { IIosMockupVariantProps } from "../variants-interface";
 
 export default function IPhoneLegacyLandscape(props: PropsWithChildren<IIosMockupVariantProps>) {
-	const { screenWidth, frameColor, statusbarColor } = props;
+	const { screenWidth, frameColor, frameOnly, statusbarColor } = props;
 	const styles = useMemo(() => {
-		return getStyles(screenWidth, frameColor, statusbarColor);
-	}, [screenWidth, frameColor, statusbarColor]);
+		return getStyles(screenWidth, frameColor, statusbarColor, frameOnly);
+	}, [screenWidth, frameColor, statusbarColor, frameOnly]);
+
+	const flex1 = useMemo<ViewStyle>(() => {
+		return { flex: 1 };
+	}, []);
 
 	return (
 		<View style={styles.container}>
 			<View style={styles.upperBezel}>
 				<View style={styles.camSpeakerCont}>
 					<View style={styles.speaker}>
-						<View style={styles.camera}></View>
+						<View style={styles.camera} />
 					</View>
 				</View>
 			</View>
@@ -22,22 +26,30 @@ export default function IPhoneLegacyLandscape(props: PropsWithChildren<IIosMocku
 				{/* screen */}
 				<View style={styles.screen}>
 					{/* screen content */}
-					<View style={{ flex: 1 }}>{props.children}</View>
+					<View style={flex1}>{props.children}</View>
 				</View>
 			</View>
 			<View style={styles.lowerBezel}>
-				<View style={styles.homeButoon}></View>
+				<View style={styles.homeButoon} />
 			</View>
-
-			<View style={styles.silenceSwitch} />
-			<View style={styles.volumeUp} />
-			<View style={styles.volumeDown} />
-			<View style={styles.power} />
+			{!frameOnly && (
+				<>
+					<View style={styles.silenceSwitch} />
+					<View style={styles.volumeUp} />
+					<View style={styles.volumeDown} />
+					<View style={styles.power} />
+				</>
+			)}
 		</View>
 	);
 }
 
-const getStyles = (screenWidth: number, frameColor: ColorValue, statusbarColor: ColorValue) => {
+const getStyles = (
+	screenWidth: number,
+	frameColor: ColorValue,
+	statusbarColor: ColorValue,
+	frameOnly: boolean,
+) => {
 	const getSizeWithRatio = (size: number) => {
 		const sizeRatio = Math.floor((screenWidth * size) / 667);
 		return Math.max(sizeRatio, 1);
@@ -64,7 +76,7 @@ const getStyles = (screenWidth: number, frameColor: ColorValue, statusbarColor: 
 			borderRadius: bezelRadius,
 			backgroundColor: frameColor,
 			flexDirection: "row",
-			marginVertical: frameButtonHeight - HALF_FRAME_WIDTH,
+			marginVertical: frameOnly ? 0 : frameButtonHeight - HALF_FRAME_WIDTH,
 		},
 		frame: {
 			backgroundColor: frameColor,

--- a/src/ios-mockup/variants/phone/IPhoneLegacyPortrait.tsx
+++ b/src/ios-mockup/variants/phone/IPhoneLegacyPortrait.tsx
@@ -1,19 +1,23 @@
 import React, { PropsWithChildren, useMemo } from "react";
-import { ColorValue, StyleSheet, View } from "react-native";
+import { ColorValue, StyleSheet, View, ViewStyle } from "react-native";
 import { IIosMockupVariantProps } from "../variants-interface";
 
 export default function IPhoneLegacyPortrait(props: PropsWithChildren<IIosMockupVariantProps>) {
-	const { screenWidth, frameColor, statusbarColor, hideStatusBar } = props;
+	const { screenWidth, frameColor, frameOnly, statusbarColor, hideStatusBar } = props;
 	const styles = useMemo(() => {
-		return getStyles(screenWidth, frameColor, statusbarColor);
-	}, [screenWidth, frameColor, statusbarColor]);
+		return getStyles(screenWidth, frameColor, statusbarColor, frameOnly);
+	}, [screenWidth, frameColor, statusbarColor, frameOnly]);
+
+	const flex1 = useMemo<ViewStyle>(() => {
+		return { flex: 1 };
+	}, []);
 
 	return (
 		<View style={styles.container}>
 			<View style={styles.upperBezel}>
 				<View style={styles.camSpeakerCont}>
 					<View style={styles.speaker}>
-						<View style={styles.camera}></View>
+						<View style={styles.camera} />
 					</View>
 				</View>
 			</View>
@@ -21,24 +25,32 @@ export default function IPhoneLegacyPortrait(props: PropsWithChildren<IIosMockup
 			<View style={styles.frame}>
 				{/* screen */}
 				<View style={styles.screen}>
-					{hideStatusBar === false && <View style={styles.statusbar}></View>}
+					{hideStatusBar === false && <View style={styles.statusbar} />}
 					{/* screen content */}
-					<View style={{ flex: 1 }}>{props.children}</View>
+					<View style={flex1}>{props.children}</View>
 				</View>
 			</View>
 			<View style={styles.lowerBezel}>
-				<View style={styles.homeButoon}></View>
+				<View style={styles.homeButoon} />
 			</View>
-
-			<View style={styles.silenceSwitch} />
-			<View style={styles.volumeUp} />
-			<View style={styles.volumeDown} />
-			<View style={styles.powerPortrait} />
+			{!frameOnly && (
+				<>
+					<View style={styles.silenceSwitch} />
+					<View style={styles.volumeUp} />
+					<View style={styles.volumeDown} />
+					<View style={styles.powerPortrait} />
+				</>
+			)}
 		</View>
 	);
 }
 
-const getStyles = (screenWidth: number, frameColor: ColorValue, statusbarColor: ColorValue) => {
+const getStyles = (
+	screenWidth: number,
+	frameColor: ColorValue,
+	statusbarColor: ColorValue,
+	frameOnly: boolean,
+) => {
 	const getSizeWithRatio = (size: number) => {
 		const sizeRatio = Math.floor((screenWidth * size) / 375);
 		return Math.max(sizeRatio, 1);
@@ -62,7 +74,7 @@ const getStyles = (screenWidth: number, frameColor: ColorValue, statusbarColor: 
 			height: mHeight + upperBezelHeight + lowerBezelHeight,
 			borderRadius: getSizeWithRatio(60),
 			backgroundColor: frameColor,
-			marginHorizontal: frameButtonWidth - HALF_FRAME_WIDTH,
+			marginHorizontal: frameOnly ? 0 : frameButtonWidth - HALF_FRAME_WIDTH,
 		},
 		frame: {
 			backgroundColor: frameColor,

--- a/src/ios-mockup/variants/phone/IPhoneNotchLandscape.tsx
+++ b/src/ios-mockup/variants/phone/IPhoneNotchLandscape.tsx
@@ -1,18 +1,24 @@
 import React, { PropsWithChildren, useMemo } from "react";
-import { ColorValue, StyleSheet, View } from "react-native";
+import { ColorValue, StyleSheet, View, ViewStyle } from "react-native";
 import { IIosMockupVariantProps } from "../variants-interface";
 
 export default function IPhoneNotchLandscape(props: PropsWithChildren<IIosMockupVariantProps>) {
 	const {
+		screenWidth,
 		frameColor,
+		frameOnly,
 		statusbarColor,
 		hideStatusBar,
 		hideNavigationBar,
 		transparentNavigationBar,
 	} = props;
 	const styles = useMemo(() => {
-		return getStyles(props.screenWidth, frameColor, statusbarColor);
-	}, [props.screenWidth, frameColor, statusbarColor]);
+		return getStyles(screenWidth, frameColor, statusbarColor, frameOnly);
+	}, [screenWidth, frameColor, statusbarColor, frameOnly]);
+
+	const flex1 = useMemo<ViewStyle>(() => {
+		return { flex: 1 };
+	}, []);
 
 	return (
 		<View style={styles.container}>
@@ -22,12 +28,12 @@ export default function IPhoneNotchLandscape(props: PropsWithChildren<IIosMockup
 				<View style={styles.screen}>
 					{hideStatusBar === false && (
 						<View style={styles.notchContainer}>
-							<View style={styles.notch}></View>
+							<View style={styles.notch} />
 						</View>
 					)}
 					{/* screen content */}
-					<View style={{ flex: 1 }}>
-						<View style={{ flex: 1 }}>{props.children}</View>
+					<View style={flex1}>
+						<View style={flex1}>{props.children}</View>
 						{hideNavigationBar === false && transparentNavigationBar === false && (
 							<View style={styles.swipeContainer}>
 								<View style={styles.swipeBar} />
@@ -38,7 +44,7 @@ export default function IPhoneNotchLandscape(props: PropsWithChildren<IIosMockup
 				</View>
 				{hideStatusBar && (
 					<View pointerEvents="none" style={styles.notchContainerFullScreen}>
-						<View style={styles.notch}></View>
+						<View style={styles.notch} />
 					</View>
 				)}
 				{hideNavigationBar === false && transparentNavigationBar && (
@@ -48,15 +54,24 @@ export default function IPhoneNotchLandscape(props: PropsWithChildren<IIosMockup
 				)}
 			</View>
 			<View style={styles.notchPad} />
-			<View style={styles.silenceSwitch} />
-			<View style={styles.volumeUp} />
-			<View style={styles.volumeDown} />
-			<View style={styles.powerPortrait} />
+			{!frameOnly && (
+				<>
+					<View style={styles.silenceSwitch} />
+					<View style={styles.volumeUp} />
+					<View style={styles.volumeDown} />
+					<View style={styles.powerPortrait} />
+				</>
+			)}
 		</View>
 	);
 }
 
-const getStyles = (screenWidth: number, frameColor: ColorValue, statusbarColor: ColorValue) => {
+const getStyles = (
+	screenWidth: number,
+	frameColor: ColorValue,
+	statusbarColor: ColorValue,
+	frameOnly: boolean,
+) => {
 	const getSizeWithRatio = (size: number) => {
 		const sizeRatio = Math.floor((screenWidth * size) / 844);
 		return Math.max(sizeRatio, 1);
@@ -81,7 +96,7 @@ const getStyles = (screenWidth: number, frameColor: ColorValue, statusbarColor: 
 			borderRadius: bezelRadius,
 			backgroundColor: frameColor,
 			flexDirection: "row",
-			marginVertical: frameButtonHeight - HALF_FRAME_WIDTH,
+			marginVertical: frameOnly ? 0 : frameButtonHeight - HALF_FRAME_WIDTH,
 		},
 		frame: {
 			width: widthAndFrame,

--- a/src/ios-mockup/variants/phone/IPhoneNotchPortrait.tsx
+++ b/src/ios-mockup/variants/phone/IPhoneNotchPortrait.tsx
@@ -1,18 +1,24 @@
 import React, { PropsWithChildren, useMemo } from "react";
-import { ColorValue, StyleSheet, View } from "react-native";
+import { ColorValue, StyleSheet, View, ViewStyle } from "react-native";
 import { IIosMockupVariantProps } from "../variants-interface";
 
 export default function IPhoneNotchPortrait(props: PropsWithChildren<IIosMockupVariantProps>) {
 	const {
+		screenWidth,
 		frameColor,
+		frameOnly,
 		statusbarColor,
 		hideStatusBar,
 		hideNavigationBar,
 		transparentNavigationBar,
 	} = props;
 	const styles = useMemo(() => {
-		return getStyles(props.screenWidth, frameColor, statusbarColor);
-	}, [props.screenWidth, frameColor, statusbarColor]);
+		return getStyles(screenWidth, frameColor, statusbarColor, frameOnly);
+	}, [screenWidth, frameColor, statusbarColor, frameOnly]);
+
+	const flex1 = useMemo<ViewStyle>(() => {
+		return { flex: 1 };
+	}, []);
 
 	return (
 		<View style={styles.container}>
@@ -22,11 +28,11 @@ export default function IPhoneNotchPortrait(props: PropsWithChildren<IIosMockupV
 				<View style={styles.screen}>
 					{hideStatusBar === false && (
 						<View style={styles.notchContainer}>
-							<View style={styles.notch}></View>
+							<View style={styles.notch} />
 						</View>
 					)}
 					{/* screen content */}
-					<View style={{ flex: 1 }}>{props.children}</View>
+					<View style={flex1}>{props.children}</View>
 					{hideNavigationBar === false && transparentNavigationBar === false && (
 						<View style={styles.swipeContainer}>
 							<View style={styles.swipeBar} />
@@ -35,7 +41,7 @@ export default function IPhoneNotchPortrait(props: PropsWithChildren<IIosMockupV
 				</View>
 				{hideStatusBar && (
 					<View pointerEvents="none" style={styles.notchContainerFullScreen}>
-						<View style={styles.notch}></View>
+						<View style={styles.notch} />
 					</View>
 				)}
 				{hideNavigationBar === false && transparentNavigationBar && (
@@ -45,15 +51,24 @@ export default function IPhoneNotchPortrait(props: PropsWithChildren<IIosMockupV
 				)}
 			</View>
 			<View style={styles.notchPad} />
-			<View style={styles.silenceSwitch} />
-			<View style={styles.volumeUp} />
-			<View style={styles.volumeDown} />
-			<View style={styles.powerPortrait} />
+			{!frameOnly && (
+				<>
+					<View style={styles.silenceSwitch} />
+					<View style={styles.volumeUp} />
+					<View style={styles.volumeDown} />
+					<View style={styles.powerPortrait} />
+				</>
+			)}
 		</View>
 	);
 }
 
-const getStyles = (screenWidth: number, frameColor: ColorValue, statusbarColor: ColorValue) => {
+const getStyles = (
+	screenWidth: number,
+	frameColor: ColorValue,
+	statusbarColor: ColorValue,
+	frameOnly: boolean,
+) => {
 	const getSizeWithRatio = (size: number) => {
 		const sizeRatio = Math.floor((screenWidth * size) / 390);
 		return Math.max(sizeRatio, 1);
@@ -77,7 +92,7 @@ const getStyles = (screenWidth: number, frameColor: ColorValue, statusbarColor: 
 			height: heightAndFrame,
 			borderRadius: bezelRadius,
 			backgroundColor: frameColor,
-			marginHorizontal: frameButtonWidth - HALF_FRAME_WIDTH,
+			marginHorizontal: frameOnly ? 0 : frameButtonWidth - HALF_FRAME_WIDTH,
 		},
 		frame: {
 			width: widthAndFrame,

--- a/src/ios-mockup/variants/tab/IPadLegacyLandscape.tsx
+++ b/src/ios-mockup/variants/tab/IPadLegacyLandscape.tsx
@@ -1,5 +1,5 @@
 import React, { PropsWithChildren, useMemo } from "react";
-import { ColorValue, StyleSheet, View } from "react-native";
+import { ColorValue, StyleSheet, View, ViewStyle } from "react-native";
 import { IIosMockupVariantProps } from "../variants-interface";
 
 export default function IPadLegacyLandscape(props: PropsWithChildren<IIosMockupVariantProps>) {
@@ -8,11 +8,15 @@ export default function IPadLegacyLandscape(props: PropsWithChildren<IIosMockupV
 		return getStyles(screenWidth, frameColor, statusbarColor);
 	}, [screenWidth, frameColor, statusbarColor]);
 
+	const flex1 = useMemo<ViewStyle>(() => {
+		return { flex: 1 };
+	}, []);
+
 	return (
 		<View style={styles.container}>
 			<View style={styles.upperBezel}>
 				<View style={styles.camSpeakerCont}>
-					<View style={styles.camera}></View>
+					<View style={styles.camera} />
 				</View>
 			</View>
 			{/* frame */}
@@ -21,11 +25,11 @@ export default function IPadLegacyLandscape(props: PropsWithChildren<IIosMockupV
 				<View style={styles.screen}>
 					{hideStatusBar === false && <View style={styles.statusbar} />}
 					{/* screen content */}
-					<View style={{ flex: 1 }}>{props.children}</View>
+					<View style={flex1}>{props.children}</View>
 				</View>
 			</View>
 			<View style={styles.lowerBezel}>
-				<View style={styles.homeButoon}></View>
+				<View style={styles.homeButoon} />
 			</View>
 		</View>
 	);

--- a/src/ios-mockup/variants/tab/IPadLegacyPortrait.tsx
+++ b/src/ios-mockup/variants/tab/IPadLegacyPortrait.tsx
@@ -1,5 +1,5 @@
 import React, { PropsWithChildren, useMemo } from "react";
-import { ColorValue, StyleSheet, View } from "react-native";
+import { ColorValue, StyleSheet, View, ViewStyle } from "react-native";
 import { IIosMockupVariantProps } from "../variants-interface";
 
 export default function IPadLegacyPortrait(props: PropsWithChildren<IIosMockupVariantProps>) {
@@ -8,11 +8,15 @@ export default function IPadLegacyPortrait(props: PropsWithChildren<IIosMockupVa
 		return getStyles(screenWidth, frameColor, statusbarColor);
 	}, [screenWidth, frameColor, statusbarColor]);
 
+	const flex1 = useMemo<ViewStyle>(() => {
+		return { flex: 1 };
+	}, []);
+
 	return (
 		<View style={styles.container}>
 			<View style={styles.upperBezel}>
 				<View style={styles.camSpeakerCont}>
-					<View style={styles.camera}></View>
+					<View style={styles.camera} />
 				</View>
 			</View>
 			{/* frame */}
@@ -21,11 +25,11 @@ export default function IPadLegacyPortrait(props: PropsWithChildren<IIosMockupVa
 				<View style={styles.screen}>
 					{hideStatusBar === false && <View style={styles.statusbar} />}
 					{/* screen content */}
-					<View style={{ flex: 1 }}>{props.children}</View>
+					<View style={flex1}>{props.children}</View>
 				</View>
 			</View>
 			<View style={styles.lowerBezel}>
-				<View style={styles.homeButoon}></View>
+				<View style={styles.homeButoon} />
 			</View>
 		</View>
 	);

--- a/src/ios-mockup/variants/tab/IPadModernLandscape.tsx
+++ b/src/ios-mockup/variants/tab/IPadModernLandscape.tsx
@@ -1,18 +1,24 @@
 import React, { PropsWithChildren, useMemo } from "react";
-import { ColorValue, StyleSheet, View } from "react-native";
+import { ColorValue, StyleSheet, View, ViewStyle } from "react-native";
 import { IIosMockupVariantProps } from "../variants-interface";
 
 export default function IPadModernLandscape(props: PropsWithChildren<IIosMockupVariantProps>) {
 	const {
+		screenWidth,
 		frameColor,
+		frameOnly,
 		statusbarColor,
 		hideStatusBar,
 		hideNavigationBar,
 		transparentNavigationBar,
 	} = props;
 	const styles = useMemo(() => {
-		return getStyles(props.screenWidth, frameColor, statusbarColor);
-	}, [props.screenWidth, frameColor, statusbarColor]);
+		return getStyles(screenWidth, frameColor, statusbarColor, frameOnly);
+	}, [screenWidth, frameColor, statusbarColor, frameOnly]);
+
+	const flex1 = useMemo<ViewStyle>(() => {
+		return { flex: 1 };
+	}, []);
 
 	return (
 		<View style={styles.container}>
@@ -22,7 +28,7 @@ export default function IPadModernLandscape(props: PropsWithChildren<IIosMockupV
 				<View style={styles.screen}>
 					{hideStatusBar === false && <View style={styles.notchContainer} />}
 					{/* screen content */}
-					<View style={{ flex: 1 }}>{props.children}</View>
+					<View style={flex1}>{props.children}</View>
 					{hideNavigationBar === false && transparentNavigationBar === false && (
 						<View style={styles.swipeContainer}>
 							<View style={styles.swipeBar} />
@@ -38,14 +44,23 @@ export default function IPadModernLandscape(props: PropsWithChildren<IIosMockupV
 					</View>
 				)}
 			</View>
-			<View style={styles.volumeUp} />
-			<View style={styles.volumeDown} />
-			<View style={styles.power} />
+			{!frameOnly && (
+				<>
+					<View style={styles.volumeUp} />
+					<View style={styles.volumeDown} />
+					<View style={styles.power} />
+				</>
+			)}
 		</View>
 	);
 }
 
-const getStyles = (screenWidth: number, frameColor: ColorValue, statusbarColor: ColorValue) => {
+const getStyles = (
+	screenWidth: number,
+	frameColor: ColorValue,
+	statusbarColor: ColorValue,
+	frameOnly: boolean,
+) => {
 	const getSizeWithRatio = (size: number) => {
 		const sizeRatio = Math.floor((screenWidth * size) / 1194);
 		return Math.max(sizeRatio, 1);
@@ -69,8 +84,8 @@ const getStyles = (screenWidth: number, frameColor: ColorValue, statusbarColor: 
 			height: heightAndFrame,
 			borderRadius: bezelRadius,
 			backgroundColor: frameColor,
-			marginTop: frameButtonHeight - HALF_FRAME_WIDTH,
-			marginLeft: frameButtonHeight - HALF_FRAME_WIDTH,
+			marginTop: frameOnly ? 0 : frameButtonHeight - HALF_FRAME_WIDTH,
+			marginLeft: frameOnly ? 0 : frameButtonHeight - HALF_FRAME_WIDTH,
 		},
 		frame: {
 			width: widthAndFrame,
@@ -102,8 +117,9 @@ const getStyles = (screenWidth: number, frameColor: ColorValue, statusbarColor: 
 			bottom: 0,
 			width: "100%",
 			height: getSizeWithRatio(20),
+			paddingTop: getSizeWithRatio(4),
 			alignItems: "center",
-			justifyContent: "flex-end",
+			justifyContent: "center",
 		},
 		swipeContainer: {
 			width: "100%",

--- a/src/ios-mockup/variants/tab/IPadModernPortrait.tsx
+++ b/src/ios-mockup/variants/tab/IPadModernPortrait.tsx
@@ -1,18 +1,24 @@
 import React, { PropsWithChildren, useMemo } from "react";
-import { ColorValue, StyleSheet, View } from "react-native";
+import { ColorValue, StyleSheet, View, ViewStyle } from "react-native";
 import { IIosMockupVariantProps } from "../variants-interface";
 
 export default function IPadModernPortrait(props: PropsWithChildren<IIosMockupVariantProps>) {
 	const {
+		screenWidth,
 		frameColor,
+		frameOnly,
 		statusbarColor,
 		hideStatusBar,
 		hideNavigationBar,
 		transparentNavigationBar,
 	} = props;
 	const styles = useMemo(() => {
-		return getStyles(props.screenWidth, frameColor, statusbarColor);
-	}, [props.screenWidth, frameColor, statusbarColor]);
+		return getStyles(screenWidth, frameColor, statusbarColor, frameOnly);
+	}, [screenWidth, frameColor, statusbarColor, frameOnly]);
+
+	const flex1 = useMemo<ViewStyle>(() => {
+		return { flex: 1 };
+	}, []);
 
 	return (
 		<View style={styles.container}>
@@ -22,7 +28,7 @@ export default function IPadModernPortrait(props: PropsWithChildren<IIosMockupVa
 				<View style={styles.screen}>
 					{hideStatusBar === false && <View style={styles.notchContainer} />}
 					{/* screen content */}
-					<View style={{ flex: 1 }}>{props.children}</View>
+					<View style={flex1}>{props.children}</View>
 					{hideNavigationBar === false && transparentNavigationBar === false && (
 						<View style={styles.swipeContainer}>
 							<View style={styles.swipeBar} />
@@ -38,14 +44,23 @@ export default function IPadModernPortrait(props: PropsWithChildren<IIosMockupVa
 					</View>
 				)}
 			</View>
-			<View style={styles.volumeUp} />
-			<View style={styles.volumeDown} />
-			<View style={styles.power} />
+			{!frameOnly && (
+				<>
+					<View style={styles.volumeUp} />
+					<View style={styles.volumeDown} />
+					<View style={styles.power} />
+				</>
+			)}
 		</View>
 	);
 }
 
-const getStyles = (screenWidth: number, frameColor: ColorValue, statusbarColor: ColorValue) => {
+const getStyles = (
+	screenWidth: number,
+	frameColor: ColorValue,
+	statusbarColor: ColorValue,
+	frameOnly: boolean,
+) => {
 	const getSizeWithRatio = (size: number) => {
 		const sizeRatio = Math.floor((screenWidth * size) / 834);
 		return Math.max(sizeRatio, 1);
@@ -69,8 +84,8 @@ const getStyles = (screenWidth: number, frameColor: ColorValue, statusbarColor: 
 			height: heightAndFrame,
 			borderRadius: bezelRadius,
 			backgroundColor: frameColor,
-			marginTop: frameButtonWidth - HALF_FRAME_WIDTH,
-			marginRight: frameButtonWidth - HALF_FRAME_WIDTH,
+			marginTop: frameOnly ? 0 : frameButtonWidth - HALF_FRAME_WIDTH,
+			marginRight: frameOnly ? 0 : frameButtonWidth - HALF_FRAME_WIDTH,
 		},
 		frame: {
 			width: widthAndFrame,

--- a/src/ios-mockup/variants/variants-interface.ts
+++ b/src/ios-mockup/variants/variants-interface.ts
@@ -4,6 +4,8 @@ export interface IIosMockupVariantProps {
 	readonly screenWidth: number;
 	/** default: "#666666" */
 	readonly frameColor: ColorValue;
+	/** default: false */
+	readonly frameOnly: boolean;
 	/** default: "#CCCCCC" */
 	readonly statusbarColor: ColorValue;
 	/** default: false */


### PR DESCRIPTION
# Release Note
### Add `frameOnly` Props
Only the frame is shown.  
Power button and volume buttons are hidden.

### bug fix
fix the position of the swipe bar in IPadMokcup's landscape mode